### PR TITLE
Add missing DOIs to paper.bib for JOSS

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -6,6 +6,7 @@
   note = {R package version 0.4.1,
     https://irudnyts.github.io/openai/},
   url = {https://github.com/irudnyts/openai},
+  doi = {10.32614/cran.package.openai}
 }
 
 @misc{Wanjun2024,
@@ -13,6 +14,7 @@
   author = {Wanjun Gu},
   year = {2024},
   url = {https://cran.r-project.org/web/packages/gptr/index.html},
+  doi = {10.32614/cran.package.gptr}
 }
 
 @article{Lin2025,


### PR DESCRIPTION
Fixes #7

Updated /paper/paper.bib to add missing DOIs identified in the reference check summary:

- Added DOI `10.32614/cran.package.openai` to openai reference
- Added DOI `10.32614/cran.package.gptr` to gptr reference

Generated with [Claude Code](https://claude.ai/code)