### PR TITLE
Add DOIs to bibliography references

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -34,7 +34,8 @@
       eprint={2404.07654},
       archivePrefix={arXiv},
       primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2404.07654}, 
+      url={https://arxiv.org/abs/2404.07654},
+      doi={10.48550/arXiv.2404.07654}
 }
 
 
@@ -45,7 +46,8 @@
       eprint={2303.08774},
       archivePrefix={arXiv},
       primaryClass={cs.CL},
-      url={https://arxiv.org/abs/2303.08774}
+      url={https://arxiv.org/abs/2303.08774},
+      doi={10.48550/arXiv.2303.08774}
 }
 
 


### PR DESCRIPTION
This PR adds DOIs to the rollama and GPT-4 Technical Report references in paper/paper.bib.

Changes:
- Added DOI 10.48550/arXiv.2404.07654 for rollama paper
- Added DOI 10.48550/arXiv.2303.08774 for GPT-4 Technical Report

Closes #16

Generated with [Claude Code](https://claude.ai/code)